### PR TITLE
Simplify scale_map so that it doesn't depend on spacing

### DIFF
--- a/mermaid/libraries/functions/map_scale_utils.py
+++ b/mermaid/libraries/functions/map_scale_utils.py
@@ -19,7 +19,7 @@ def scale_map(map,spacing):
 
     for d in range(ndim):
         if sz[d+2] >1:
-            map_scaled[:, d, ...] = map[:, d, ...] * (2. / (sz[d + 2] - 1.) / spacing[d]) - 1.
+            map_scaled[:, d, ...] = map[:, d, ...] * 2. - 1.
         else:
             map_scaled[:, d, ...] = map[:,d,...]
 


### PR DESCRIPTION
I am not confident that this is correct, but this change simplifies the function and makes my code run when spacing of I_0 and Phi are different. There's definitely a Chesterton's fence situation though, as I do not really understand the code that this commit deletes