### PR TITLE
switch documentation version of pytorch to 1.4

### DIFF
--- a/docs/requirements_doc.txt
+++ b/docs/requirements_doc.txt
@@ -1,4 +1,3 @@
--f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 numpy>=1.17
 pynrrd
 future
@@ -8,7 +7,7 @@ tabulate
 termcolor
 cffi
 itk
-torch_nightly
+torch==1.4
 pandas
 matplotlib
 scipy


### PR DESCRIPTION
Documentation is trying to build with pytorch 1.2, but we use the argument align_corners of grid_sample which is only available in 1.4 and beyond.